### PR TITLE
Validate JSON workflow task

### DIFF
--- a/Constants.cs
+++ b/Constants.cs
@@ -14,6 +14,8 @@ namespace PropertyBrokers.OrchardCore.WorkflowAdditions
             public const string EmailFile = "PropertyBrokers.OrchardCore.WorkflowAdditions.EmailFile";
             public const string MediaCachePurge = "PropertyBrokers.OrchardCore.WorkflowAdditions.MediaCachePurge";
             public const string UsersForEach = "PropertyBrokers.OrchardCore.WorkflowAdditions.UserForEach";
+            public const string ValidateJson =
+              "PropertyBrokers.OrchardCore.WorkflowAdditions.ValidateJson";
         }
     }
 }

--- a/Display/ValidateJsonTaskDisplayDriver.cs
+++ b/Display/ValidateJsonTaskDisplayDriver.cs
@@ -1,0 +1,28 @@
+﻿using OrchardCore.Workflows.Display;
+using OrchardCore.Workflows.Models;
+using PropertyBrokers.OrchardCore.WorkflowAdditions.ValidateJson;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PropertyBrokers.OrchardCore.WorkflowAdditions.Display
+{
+    public class ValidateJsonTaskDisplayDriver : ActivityDisplayDriver<ValidateJson.ValidateJsonTask, ValidateJsonTaskViewModel>
+    {
+        protected override void EditActivity(ValidateJson.ValidateJsonTask activity, ValidateJsonTaskViewModel model)
+        {
+            model.JsonContent = activity.JsonContent.Expression;
+            model.SchemaContent = activity.SchemaContent.Expression;
+            model.SchemaValidationState = activity.SchemaValidationState.Expression;
+        }
+
+        protected override void UpdateActivity(ValidateJsonTaskViewModel model, ValidateJson.ValidateJsonTask activity)
+        {
+            activity.JsonContent = new WorkflowExpression<string>(model.JsonContent);
+            activity.SchemaContent = new WorkflowExpression<string>(model.SchemaContent);
+            activity.SchemaValidationState = new WorkflowExpression<string>(model.SchemaValidationState);
+        }
+    }
+}

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -37,3 +37,10 @@ using OrchardCore.Modules.Manifest;
     Dependencies = new[] { "OrchardCore.Workflows", "OrchardCore.Media" },
     Description = "Clear the media image cache"
     )]
+[assembly: Feature(
+    Id = Constants.Features.ValidateJson,
+    Name = "Validate JSON",
+    Category = "Workflows",
+    Dependencies = new[] { "OrchardCore.Workflows" },
+    Description = "Validates JSON given a Schema"
+    )]

--- a/PropertyBrokers.OrchardCore.WorkflowAdditions.csproj
+++ b/PropertyBrokers.OrchardCore.WorkflowAdditions.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.15" />
     <PackageReference Include="OrchardCore.ContentManagement.Abstractions" Version="1.6.0" />
     <PackageReference Include="OrchardCore.Contents" Version="1.6.0" />
     <PackageReference Include="OrchardCore.Data.Abstractions" Version="1.6.0" />

--- a/Startup.cs
+++ b/Startup.cs
@@ -9,6 +9,8 @@ using PropertyBrokers.OrchardCore.WorkflowAdditions.EmailFile;
 using PropertyBrokers.OrchardCore.WorkflowAdditions.UserForEach;
 using PropertyBrokers.OrchardCore.WorkflowAdditions.MediaCachePurge;
 using System;
+using PropertyBrokers.OrchardCore.WorkflowAdditions.Display;
+using PropertyBrokers.OrchardCore.WorkflowAdditions.ValidateJson;
 
 namespace PropertyBrokers.OrchardCore.WorkflowAdditions
 {
@@ -21,6 +23,7 @@ namespace PropertyBrokers.OrchardCore.WorkflowAdditions
             services.AddActivity<EmailFileTask, EmailFileTaskDisplayDriver>();
             services.AddActivity<UserForEachTask, UserForEachTaskDisplayDriver>();
             services.AddActivity<MediaCachePurgeTask, MediaPurgeTaskDisplayDriver>();
+            services.AddActivity<ValidateJsonTask, ValidateJsonTaskDisplayDriver>();
             services.AddScoped<ISmtpService, SmtpService>();
         }
 

--- a/ValidateJsonTask/ValidateJsonTask.cs
+++ b/ValidateJsonTask/ValidateJsonTask.cs
@@ -23,7 +23,6 @@ namespace PropertyBrokers.OrchardCore.WorkflowAdditions.ValidateJson
     {
         private readonly IWorkflowExpressionEvaluator _expressionEvaluator;
         private readonly IStringLocalizer S;
-        private readonly ISession _session;
         public ValidateJsonTask(
             IWorkflowExpressionEvaluator expressionEvaluator,
             ISession session,
@@ -32,7 +31,6 @@ namespace PropertyBrokers.OrchardCore.WorkflowAdditions.ValidateJson
         {
             _expressionEvaluator = expressionEvaluator;
             S = localizer;
-            _session = session;
         }
 
         public override string Name => nameof(ValidateJsonTask);

--- a/ValidateJsonTask/ValidateJsonTask.cs
+++ b/ValidateJsonTask/ValidateJsonTask.cs
@@ -1,0 +1,98 @@
+﻿using Fluid.Parser;
+using Microsoft.Extensions.Localization;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Schema;
+using OrchardCore.ContentManagement;
+using OrchardCore.ContentManagement.Records;
+using OrchardCore.DisplayManagement.ModelBinding;
+using OrchardCore.Workflows.Abstractions.Models;
+using OrchardCore.Workflows.Activities;
+using OrchardCore.Workflows.Models;
+using OrchardCore.Workflows.Services;
+using PropertyBrokers.OrchardCore.WorkflowAdditions.EmailFile;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using YesSql;
+
+namespace PropertyBrokers.OrchardCore.WorkflowAdditions.ValidateJson
+{
+    public class ValidateJsonTask : TaskActivity
+    {
+        private readonly IWorkflowExpressionEvaluator _expressionEvaluator;
+        private readonly IStringLocalizer S;
+        private readonly ISession _session;
+        public ValidateJsonTask(
+            IWorkflowExpressionEvaluator expressionEvaluator,
+            ISession session,
+            IStringLocalizer<EmailFileTask> localizer
+        )
+        {
+            _expressionEvaluator = expressionEvaluator;
+            S = localizer;
+            _session = session;
+        }
+
+        public override string Name => nameof(ValidateJsonTask);
+        public override LocalizedString DisplayText => S["Validate JSON Task"];
+        public override LocalizedString Category => S["Validation"];
+
+        public WorkflowExpression<string> SchemaContent
+        {
+            get => GetProperty(() => new WorkflowExpression<string>());
+            set => SetProperty(value);
+        }
+
+        public WorkflowExpression<string> JsonContent
+        {
+            get => GetProperty(() => new WorkflowExpression<string>());
+            set => SetProperty(value);
+        }
+
+        public WorkflowExpression<string> SchemaValidationState
+        {
+            get => GetProperty(() => new WorkflowExpression<string>());
+            set => SetProperty(value);
+        }
+
+        public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
+        {
+            return Outcomes(S["Passed"], S["Failed"]);
+        }
+
+        public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
+        {
+            // Retrieve the schema content item
+            string schemaContent = await _expressionEvaluator.EvaluateAsync(SchemaContent, workflowContext, null);
+            JSchema schema = JSchema.Parse(schemaContent);
+
+            // JSON body
+            string contentStr = await _expressionEvaluator.EvaluateAsync(JsonContent, workflowContext, null);
+            JObject content;
+            try
+            {
+                content = JObject.Parse(contentStr);
+            } catch (Exception ex)
+            {
+                SchemaValidationState = new WorkflowExpression<string>("Json Body Parse Error: " + ex.Message);
+                return Outcomes("Failed");
+            }
+
+            List<string> errorMessages = new();
+            // Gets all errors with JSON body, not just the first
+            content.Validate(schema, (o, e) =>
+            {   
+                errorMessages.Add(e.Message);
+            });
+
+            if(errorMessages.Count > 0)
+            {
+                SchemaValidationState = new WorkflowExpression<string>("Json Body Parse Error: " + string.Join("\n", errorMessages));
+                return Outcomes("Failed");
+            }
+            return Outcomes("Passed");
+        }
+    }
+}

--- a/ViewModel/ValidateJsonTaskViewModel.cs
+++ b/ViewModel/ValidateJsonTaskViewModel.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PropertyBrokers.OrchardCore.WorkflowAdditions.ValidateJson
+{
+    public class ValidateJsonTaskViewModel
+    {
+        [Required]
+        public string SchemaContent { get; set; }
+        public string JsonContent { get; set; }
+        public string SchemaValidationState { get; set; }
+    }
+}

--- a/Views/Items/ValidateJsonTask.Fields.Design.cshtml
+++ b/Views/Items/ValidateJsonTask.Fields.Design.cshtml
@@ -1,0 +1,6 @@
+﻿@model OrchardCore.Workflows.ViewModels.ActivityViewModel<PropertyBrokers.OrchardCore.WorkflowAdditions.ValidateJson.ValidateJsonTask>
+
+<header>
+    <h4><i class="fa fa-bolt"></i>@Model.Activity.GetTitleOrDefault(() => T["Validate JSON"])</h4>
+</header>
+<em>@Model.Activity.Name</em>

--- a/Views/Items/ValidateJsonTask.Fields.Edit.cshtml
+++ b/Views/Items/ValidateJsonTask.Fields.Edit.cshtml
@@ -1,0 +1,41 @@
+﻿@using PropertyBrokers.OrchardCore.WorkflowAdditions.ValidateJson;
+@model ValidateJsonTaskViewModel
+
+<div class="form-group" id="json-schema-content-id">
+    <label asp-for="SchemaContent">@T["JSON Schema"]</label>
+    <textarea asp-for="SchemaContent" rows="10" class="form-control"></textarea>
+    <span class="hint">@T["JSON Schema content, based on draft 4. With Liquid support."]</span>
+    <span class="hint"><a href="https://json-schema.org/draft-04/draft-zyp-json-schema-04" target="_blank">[spec]</a></span>
+</div>
+
+<div class="form-group" id="json-content">
+    <label asp-for="JsonContent">@T["JSON Content"]</label>
+    <textarea asp-for="JsonContent" rows="10" class="form-control"></textarea>
+    <span class="hint">@T["JSON Content to be validated. With Liquid support."]</span>
+</div>
+
+<style asp-name="codemirror"></style>
+<script asp-name="codemirror" depends-on="admin" at="Foot"></script>
+<script asp-name="codemirror-mode-javascript" at="Foot"></script>
+<script asp-name="codemirror-addon-mode-simple" at="Foot"></script>
+<script asp-name="codemirror-addon-mode-multiplex" at="Foot"></script>
+<script asp-name="codemirror-mode-xml" at="Foot"></script>
+<script asp-src="~/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
+
+<script at="Foot">
+    $(function () {
+        var htmlBodyEditor = CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.SchemaContent)'), {
+            lineNumbers: true,
+            styleActiveLine: true,
+            matchBrackets: true,
+            mode: { name: "liquid" },
+        });
+
+        var textBodyEditor = CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.JsonContent)'), {
+            lineNumbers: true,
+            styleActiveLine: true,
+            matchBrackets: true,
+            mode: { name: "liquid" },
+        });
+    });
+</script>

--- a/Views/Items/ValidateJsonTask.Fields.Thumbnail.cshtml
+++ b/Views/Items/ValidateJsonTask.Fields.Thumbnail.cshtml
@@ -1,0 +1,2 @@
+﻿<h4 class="card-title"><i class="fa fa-shield-alt"></i>@T["Validate JSON"]</h4>
+<p>@T["Validates JSON based on a provided schema"]</p>


### PR DESCRIPTION
[Related PR](https://github.com/PropertyBrokersDigital/PropertyBrokersPortal/pull/84)

Adds a new Workflow item that takes an input Schema and JSON Content and outputs pass/fail, saving errors to the activity on failure for easier debugging.

![image](https://github.com/PropertyBrokersDigital/PropertyBrokers.OrchardCore.WorkflowAdditions/assets/45801643/f542f462-f071-4509-b359-a454a56bd460)
Example Workflow:
1. Incoming post request with a body containing the JSON content, as well as the ContentItemId of a JSON Schema (see PR above), this is parsed into a property
2. Loads the JSON schema content item
3. Validates JSON body provided in the request with the retrieved JSON schema (note: body and schema can be written manually if this is needed, json schema supports up to json schema draft 9 if you needed to use some of draft 9 features for example) ![image](https://github.com/PropertyBrokersDigital/PropertyBrokers.OrchardCore.WorkflowAdditions/assets/45801643/680bac9a-2d63-40aa-894b-57d6c877d082)
4. Passed = if there were no validation errors, Failed = if there were validation errors or there was an error parsing the JSON body

![image](https://github.com/PropertyBrokersDigital/PropertyBrokers.OrchardCore.WorkflowAdditions/assets/45801643/01451c4e-63b8-49ae-8b69-51cc01050be4)
Validation errors are logged in the SchemaValidationState expression in the validation activity in a newline separated list

From here, the data would then be loaded in to, for example, an email template via the merge tags feature.

