### PR TITLE
Update ContentForEach and ProcessMJMLTask

### DIFF
--- a/ContentForEach/ContentForEachTask.cs
+++ b/ContentForEach/ContentForEachTask.cs
@@ -23,17 +23,15 @@ namespace PropertyBrokers.OrchardCore.WorkflowAdditions.ContentForEach
     {
         readonly IStringLocalizer S;
         private readonly ISession _session;
-        private readonly IWorkflowScriptEvaluator _scriptEvaluator;
         private readonly IWorkflowExpressionEvaluator _expressionEvaluator;
         private readonly ShellDescriptor _shellDescriptor;
         private readonly IServiceProvider _serviceProvider;
         private int _currentPage = 0;
 
-        public ContentForEachTask(IWorkflowScriptEvaluator scriptEvaluator, IWorkflowExpressionEvaluator expressionEvaluator,
+        public ContentForEachTask(IWorkflowExpressionEvaluator expressionEvaluator,
             IStringLocalizer<ContentForEachTask> localizer, ISession session, ShellDescriptor shellDescriptor,
             IServiceProvider serviceProvider)
         {
-            _scriptEvaluator = scriptEvaluator;
             _session = session;
             S = localizer;
             _shellDescriptor = shellDescriptor;

--- a/ContentForEach/ContentForEachTask.cs
+++ b/ContentForEach/ContentForEachTask.cs
@@ -12,8 +12,9 @@ using OrchardCore.Workflows.Services;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.Json;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using YesSql;
 
 namespace PropertyBrokers.OrchardCore.WorkflowAdditions.ContentForEach
@@ -23,17 +24,21 @@ namespace PropertyBrokers.OrchardCore.WorkflowAdditions.ContentForEach
         readonly IStringLocalizer S;
         private readonly ISession _session;
         private readonly IWorkflowScriptEvaluator _scriptEvaluator;
+        private readonly IWorkflowExpressionEvaluator _expressionEvaluator;
         private readonly ShellDescriptor _shellDescriptor;
         private readonly IServiceProvider _serviceProvider;
         private int _currentPage = 0;
 
-        public ContentForEachTask(IWorkflowScriptEvaluator scriptEvaluator, IStringLocalizer<ContentForEachTask> localizer, ISession session, ShellDescriptor shellDescriptor, IServiceProvider serviceProvider)
+        public ContentForEachTask(IWorkflowScriptEvaluator scriptEvaluator, IWorkflowExpressionEvaluator expressionEvaluator,
+            IStringLocalizer<ContentForEachTask> localizer, ISession session, ShellDescriptor shellDescriptor,
+            IServiceProvider serviceProvider)
         {
             _scriptEvaluator = scriptEvaluator;
             _session = session;
             S = localizer;
             _shellDescriptor = shellDescriptor;
             _serviceProvider = serviceProvider;
+            _expressionEvaluator = expressionEvaluator;
         }
 
         public override string Name => nameof(ContentForEachTask);
@@ -60,6 +65,8 @@ namespace PropertyBrokers.OrchardCore.WorkflowAdditions.ContentForEach
 
             if (Index >= ContentItems.Count && !await FetchNextBatchAsync(workflowContext))
             {
+                //Need to reset current page when done so that it can be reused in the workflow loop
+                _currentPage = 0;
                 return Outcomes("Done");
             }
 
@@ -97,10 +104,11 @@ namespace PropertyBrokers.OrchardCore.WorkflowAdditions.ContentForEach
                 throw new InvalidOperationException(S[$"Failed to retrieve the query {Query} (Have you changed, deleted the query or disabled the feature?)"]);
             }
             if (Parameters == null) Parameters = new WorkflowExpression<string>();
-            string queryParameters = await _scriptEvaluator.EvaluateAsync(Parameters, workflowContext, null);
 
-            var parameters = !string.IsNullOrEmpty(queryParameters) ?
-                JsonSerializer.Deserialize<Dictionary<string, object>>(queryParameters)
+            string queryParameters = await _expressionEvaluator.EvaluateAsync(Parameters, workflowContext, null);
+            
+            var parameters = !string.IsNullOrEmpty(queryParameters)
+                ? JsonConvert.DeserializeObject<Dictionary<string,object>>(queryParameters)
                 : new Dictionary<string, object>();
 
             if (PageSize > 0)
@@ -112,9 +120,16 @@ namespace PropertyBrokers.OrchardCore.WorkflowAdditions.ContentForEach
             try
             {
                 IQueryResults results = await _queryManager.ExecuteQueryAsync(query, parameters);
-                foreach (ContentItem item in results.Items)
+                if (results.Items is List<JObject> jObjectList)
                 {
-                    contentItems.Add(item);
+                    contentItems.AddRange(jObjectList.Select(temp => temp.ToObject<ContentItem>()));
+                }
+                else
+                {
+                    foreach (ContentItem item in results.Items)
+                    {
+                        contentItems.Add(item);
+                    }
                 }
             }
             catch (Exception e)

--- a/ProcessMjmlTemplateTask/ProcessMjmlTemplateTask.cs
+++ b/ProcessMjmlTemplateTask/ProcessMjmlTemplateTask.cs
@@ -59,7 +59,7 @@ namespace PropertyBrokers.OrchardCore.WorkflowAdditions.ProcessMjmlTemplate
 
             var builder = new StubbleBuilder().Configure(settings => settings.AddJsonNet()).Build();
 
-           string parsedMustacheTemplate = builder.Render(mjmlTemplate, mergeTags, new RenderSettings
+           string parsedMustacheTemplate = await builder.RenderAsync(mjmlTemplate, mergeTags, new RenderSettings
             {
                 SkipHtmlEncoding = true
             });

--- a/ProcessMjmlTemplateTask/ProcessMjmlTemplateTask.cs
+++ b/ProcessMjmlTemplateTask/ProcessMjmlTemplateTask.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Extensions.Localization;
 using Mjml.Net;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using OrchardCore.Workflows.Abstractions.Models;
 using OrchardCore.Workflows.Activities;
@@ -9,11 +8,9 @@ using OrchardCore.Workflows.Services;
 using PropertyBrokers.OrchardCore.WorkflowAdditions.EmailFile;
 using Stubble.Core.Builders;
 using Stubble.Extensions.JsonNet;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
+using Stubble.Core.Settings;
 
 namespace PropertyBrokers.OrchardCore.WorkflowAdditions.ProcessMjmlTemplate
 {
@@ -62,8 +59,10 @@ namespace PropertyBrokers.OrchardCore.WorkflowAdditions.ProcessMjmlTemplate
 
             var builder = new StubbleBuilder().Configure(settings => settings.AddJsonNet()).Build();
 
-            string parsedMustacheTemplate = builder.Render(mjmlTemplate, mergeTags);
-
+           string parsedMustacheTemplate = builder.Render(mjmlTemplate, mergeTags, new RenderSettings
+            {
+                SkipHtmlEncoding = true
+            });
             MjmlRenderer mjmlRenderer = new();
             MjmlOptions mjmlOptions = new()
             {


### PR DESCRIPTION
### Content For Each Task
 - Switched from scriptevaluator to expressionevaluator
 - Reset currentPage to 0 when outcome is done
    (This was causing issues when the Content for each task was used multiple times during a workflow, after a done outcome had been fulfilled)
 - Switched to JsonConvert from JsonSerializer (Was getting issues converting queryParams to Dict)
 - Added check if result returned is a JObject, if so, convert to contentItem
 
 
 ### ProcessMJMLTask
 - Implemented ability to push through HTML (Used for Conditional Bed Bath Garage layout)