### PR TITLE
Nuget packages

### DIFF
--- a/Display/EmailFileTaskDisplayDriver.cs
+++ b/Display/EmailFileTaskDisplayDriver.cs
@@ -1,8 +1,5 @@
-using OrchardCore.Email.Workflows.Activities;
-using OrchardCore.Email.Workflows.ViewModels;
 using OrchardCore.Workflows.Display;
 using OrchardCore.Workflows.Models;
-using OrchardCore.Email;
 
 namespace PropertyBrokers.OrchardCore.WorkflowAdditions.EmailFile
 {

--- a/EmailFileTask/EmailFileTask.cs
+++ b/EmailFileTask/EmailFileTask.cs
@@ -1,39 +1,45 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
 
-using OrchardCore.Email;
 using OrchardCore.Workflows.Abstractions.Models;
 using OrchardCore.Workflows.Activities;
 using OrchardCore.Workflows.Models;
 using OrchardCore.Workflows.Services;
+using PropertyBrokersPortal.Email;
+using PropertyBrokersPortal.Email.Models;
 
 namespace PropertyBrokers.OrchardCore.WorkflowAdditions.EmailFile
 {
     public class EmailFileTask : TaskActivity
     {
-        private readonly IEmailService _emailService;
+        private readonly IEmailSender _emailSender;
         private readonly IWorkflowExpressionEvaluator _expressionEvaluator;
         private readonly IStringLocalizer S;
         private readonly HtmlEncoder _htmlEncoder;
+        private readonly EmailSenderSettings _emailSettings;
 
         private static readonly HttpClient _httpClient = new HttpClient();
 
         public EmailFileTask(
-            IEmailService emailService,
+            IEmailSender emailSender,
             IWorkflowExpressionEvaluator expressionEvaluator,
             IStringLocalizer<EmailFileTask> localizer,
-            HtmlEncoder htmlEncoder
+            HtmlEncoder htmlEncoder,
+            IOptions<EmailSenderSettings> emailSettings
         )
         {
             _expressionEvaluator = expressionEvaluator;
             S = localizer;
             _htmlEncoder = htmlEncoder;
-            _emailService = emailService;
+            _emailSender = emailSender;
+            _emailSettings = emailSettings.Value;
         }
 
         public override string Name => nameof(EmailFileTask);
@@ -128,7 +134,7 @@ namespace PropertyBrokers.OrchardCore.WorkflowAdditions.EmailFile
             var attachmentUrl = await _expressionEvaluator.EvaluateAsync(AttachmentUrl, workflowContext, null);
             var request = new HttpRequestMessage(new HttpMethod("GET"), attachmentUrl);
             var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseContentRead);
-            var attachments = new List<MailMessageAttachment>();
+            var attachments = new List<EmailAttachment>();
 
             // Email setup
             var author = await _expressionEvaluator.EvaluateAsync(Author, workflowContext, null);
@@ -140,23 +146,23 @@ namespace PropertyBrokers.OrchardCore.WorkflowAdditions.EmailFile
             var subject = await _expressionEvaluator.EvaluateAsync(Subject, workflowContext, null);
             var body = await _expressionEvaluator.EvaluateAsync(Body, workflowContext, IsBodyHtml ? _htmlEncoder : null);
 
-            var message = new MailMessage
+            // Use workflow Author/Sender if provided, fall back to appsettings
+            var fromAddress = !string.IsNullOrWhiteSpace(author) ? author.Trim()
+                : !string.IsNullOrWhiteSpace(sender) ? sender.Trim()
+                : _emailSettings.FromAddress;
+
+            var message = new SendEmailRequest
             {
-                From = author?.Trim() ?? sender?.Trim(),
-                To = recipients.Trim(),
-                Cc = cc?.Trim(),
-                Bcc = bcc?.Trim(),
+                From = fromAddress,
+                To = SplitAddresses(recipients),
+                Cc = SplitAddresses(cc),
+                Bcc = SplitAddresses(bcc),
                 ReplyTo = replyTo?.Trim(),
-                Subject = subject.Trim(),
-                Body = body?.Trim(),
+                Subject = subject?.Trim() ?? string.Empty,
+                Body = body?.Trim() ?? string.Empty,
                 IsHtmlBody = IsBodyHtml,
                 Attachments = attachments
             };
-
-            if (!String.IsNullOrWhiteSpace(sender))
-            {
-                message.Sender = sender.Trim();
-            }
 
             // Handle attachment if response is successful
             if (response.IsSuccessStatusCode)
@@ -187,15 +193,16 @@ namespace PropertyBrokers.OrchardCore.WorkflowAdditions.EmailFile
                     }
                 }
 
-                await using var ms = await response.Content.ReadAsStreamAsync();
-                var attachment = new MailMessageAttachment
+                var contentBytes = await response.Content.ReadAsByteArrayAsync();
+                var attachment = new EmailAttachment
                 {
-                    Stream = ms,
-                    Filename = fileName
+                    FileName = fileName,
+                    ContentBytes = contentBytes,
+                    ContentType = response.Content.Headers.ContentType?.MediaType
                 };
                 attachments.Add(attachment);
 
-                var result = await _emailService.SendAsync(message);
+                var result = await _emailSender.SendAsync(message);
                 workflowContext.LastResult = result;
                 if (!result.Succeeded)
                 {
@@ -204,7 +211,7 @@ namespace PropertyBrokers.OrchardCore.WorkflowAdditions.EmailFile
             }
             else if (SendWithNoAttachment)
             {
-                var result = await _emailService.SendAsync(message);
+                var result = await _emailSender.SendAsync(message);
                 workflowContext.LastResult = result;
                 if (!result.Succeeded)
                 {
@@ -213,6 +220,17 @@ namespace PropertyBrokers.OrchardCore.WorkflowAdditions.EmailFile
             }
 
             return Outcomes("Done");
+        }
+
+        private static List<string> SplitAddresses(string addresses)
+        {
+            if (string.IsNullOrWhiteSpace(addresses))
+                return [];
+
+            return addresses.Split([',', ';'], StringSplitOptions.RemoveEmptyEntries)
+                .Select(a => a.Trim())
+                .Where(a => !string.IsNullOrEmpty(a))
+                .ToList();
         }
     }
 }

--- a/EmailFileTask/EmailFileTask.cs
+++ b/EmailFileTask/EmailFileTask.cs
@@ -147,9 +147,11 @@ namespace PropertyBrokers.OrchardCore.WorkflowAdditions.EmailFile
             var body = await _expressionEvaluator.EvaluateAsync(Body, workflowContext, IsBodyHtml ? _htmlEncoder : null);
 
             // Use workflow Author/Sender if provided, fall back to appsettings
-            var fromAddress = !string.IsNullOrWhiteSpace(author) ? author.Trim()
-                : !string.IsNullOrWhiteSpace(sender) ? sender.Trim()
-                : _emailSettings.FromAddress;
+            var fromAddress = _emailSettings.FromAddress;
+            if (!string.IsNullOrWhiteSpace(author))
+                fromAddress = author.Trim();
+            else if (!string.IsNullOrWhiteSpace(sender))
+                fromAddress = sender.Trim();
 
             var message = new SendEmailRequest
             {

--- a/ProcessMjmlTemplateTask/ProcessMjmlTemplateTask.cs
+++ b/ProcessMjmlTemplateTask/ProcessMjmlTemplateTask.cs
@@ -1,16 +1,13 @@
 ﻿using Microsoft.Extensions.Localization;
-using Mjml.Net;
 using Newtonsoft.Json.Linq;
 using OrchardCore.Workflows.Abstractions.Models;
 using OrchardCore.Workflows.Activities;
 using OrchardCore.Workflows.Models;
 using OrchardCore.Workflows.Services;
+using PropertyBrokers.OrchardCore.EmailTemplating.Services;
 using PropertyBrokers.OrchardCore.WorkflowAdditions.EmailFile;
-using Stubble.Core.Builders;
-using Stubble.Extensions.JsonNet;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Stubble.Core.Settings;
 
 namespace PropertyBrokers.OrchardCore.WorkflowAdditions.ProcessMjmlTemplate
 {
@@ -18,13 +15,17 @@ namespace PropertyBrokers.OrchardCore.WorkflowAdditions.ProcessMjmlTemplate
     public class ProcessMjmlTemplateTask : TaskActivity
     {
         private readonly IWorkflowExpressionEvaluator _expressionEvaluator;
+        private readonly IMjmlTemplateService _mjmlTemplateService;
         private readonly IStringLocalizer S;
+
         public ProcessMjmlTemplateTask(
             IWorkflowExpressionEvaluator expressionEvaluator,
+            IMjmlTemplateService mjmlTemplateService,
             IStringLocalizer<EmailFileTask> localizer
         )
         {
             _expressionEvaluator = expressionEvaluator;
+            _mjmlTemplateService = mjmlTemplateService;
             S = localizer;
         }
 
@@ -57,22 +58,8 @@ namespace PropertyBrokers.OrchardCore.WorkflowAdditions.ProcessMjmlTemplate
 
             string mjmlTemplate = await _expressionEvaluator.EvaluateAsync(EmailTemplateContent, workflowContext, null);
 
-            var builder = new StubbleBuilder().Configure(settings => settings.AddJsonNet()).Build();
+            var html = await _mjmlTemplateService.ProcessMjmlTemplateAsync(mjmlTemplate, mergeTags);
 
-           string parsedMustacheTemplate = await builder.RenderAsync(mjmlTemplate, mergeTags, new RenderSettings
-            {
-                SkipHtmlEncoding = true
-            });
-            MjmlRenderer mjmlRenderer = new();
-            MjmlOptions mjmlOptions = new()
-            {
-                Beautify = true
-            };
-
-            // errors don't prevent build, usually related to mjml attributes
-            // if there is a real error, it should either fault, or be VERY obvious otherwise
-            var (html, errors) = mjmlRenderer.Render(parsedMustacheTemplate, mjmlOptions);
-            
             workflowContext.Properties["ProcessMjmlTemplateTaskOutput"] = html;
             return Outcomes("Done");
         }

--- a/PropertyBrokers.OrchardCore.WorkflowAdditions.csproj
+++ b/PropertyBrokers.OrchardCore.WorkflowAdditions.csproj
@@ -17,12 +17,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Mjml.Net" Version="4.8.0" />
 		<PackageReference Include="NETCore.MailKit" Version="2.1.0" />
 		<PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
 		<PackageReference Include="OrchardCore.Module.Targets" Version="2.1.7" />
-		<PackageReference Include="Stubble.Core" Version="1.10.8" />
-		<PackageReference Include="Stubble.Extensions.JsonNet" Version="1.2.3" />
 		<PackageReference Include="OrchardCore.Contents" Version="2.1.7" />
 		<PackageReference Include="OrchardCore.Email" Version="2.1.7" />
 		<PackageReference Include="OrchardCore.Queries" Version="2.1.7" />
@@ -36,5 +33,9 @@
 		<PackageReference Include="OrchardCore.Search.AzureAI.Core" Version="2.1.7" />
 		<PackageReference Include="PropertyBrokersDigital.Email" Version="1.0.0" />
 		<PackageReference Include="PropertyBrokersDigital.Email.Graph" Version="1.0.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\PropertyBrokers.OrchardCore.ContentTypeAdditions\PropertyBrokers.OrchardCore.EmailTemplating\PropertyBrokers.OrchardCore.EmailTemplating.csproj" />
 	</ItemGroup>
 </Project>

--- a/PropertyBrokers.OrchardCore.WorkflowAdditions.csproj
+++ b/PropertyBrokers.OrchardCore.WorkflowAdditions.csproj
@@ -34,5 +34,7 @@
 		<PackageReference Include="OrchardCore.DisplayManagement" Version="2.1.7" />
 		<PackageReference Include="OrchardCore.Media.Abstractions" Version="2.1.7" />
 		<PackageReference Include="OrchardCore.Search.AzureAI.Core" Version="2.1.7" />
+		<PackageReference Include="PropertyBrokersDigital.Email" Version="1.0.0" />
+		<PackageReference Include="PropertyBrokersDigital.Email.Graph" Version="1.0.0" />
 	</ItemGroup>
 </Project>

--- a/Startup.cs
+++ b/Startup.cs
@@ -1,9 +1,11 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Email = OrchardCore.Email;
 using OrchardCore.Modules;
 using OrchardCore.Workflows.Helpers;
+using PropertyBrokersPortal.Email;
+using PropertyBrokersPortal.Email.Graph;
 using PropertyBrokers.OrchardCore.WorkflowAdditions.ContentForEach;
 using PropertyBrokers.OrchardCore.WorkflowAdditions.EmailFile;
 using PropertyBrokers.OrchardCore.WorkflowAdditions.UserForEach;
@@ -25,8 +27,17 @@ namespace PropertyBrokers.OrchardCore.WorkflowAdditions
     [Feature(Constants.Features.ContentForEach)]
     public class Startup: StartupBase
     {
+        private readonly IConfiguration _configuration;
+
+        public Startup(IConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
         public override void ConfigureServices(IServiceCollection services)
         {
+            services.Configure<EmailSenderSettings>(_configuration.GetSection("EmailSettings:Workflows"));
+            services.AddScoped<IEmailSender, GraphEmailSender>();
             services.AddActivity<ContentForEachTask, ContentForEachTaskDisplayDriver>();
             services.AddActivity<EmailFileTask, EmailFileTaskDisplayDriver>();
             services.AddActivity<UserForEachTask, UserForEachTaskDisplayDriver>();


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><p>Here's the PR for you:</p>
<hr>
<h2>Summary</h2>
<ul>
<li>Extracted email <strong>read operations</strong> from the <code>MSGraphAPI</code> OrchardCore module into the <code>PropertyBrokersDigital.Email.Graph</code> NuGet package (v1.1.0), making them reusable without depending on the full module</li>
<li>Added <code>IGraphEmailReader</code> / <code>GraphEmailReader</code> with 5 methods: <code>GetEmailAsync</code>, <code>GetMessageAttachmentsAsync</code>, <code>FindMessageIdByInternetMessageIdAsync</code>, <code>GetUnreadEmailsAsync</code>, <code>SearchEmailsBySubjectAsync</code></li>
<li>Migrated all consumers (6 files in JobManager, 1 in TaskServices) from <code>IGraphEmailService</code> → <code>IGraphEmailReader</code></li>
<li>Removed 5 dead methods from <code>IGraphEmailService</code> that had zero callers (<code>MarkEmailReadStatusAsync</code>, <code>GetEmailsByConversationAsync</code>, <code>CreateEmailFolderStructureAsync</code>, <code>MoveEmailToFolderAsync</code>, <code>GetOrCreateFolderByPathAsync</code>)</li>
<li>Consolidated the last MJML rendering duplication — <code>ProcessMjmlTemplateTask</code> in WorkflowAdditions now delegates to <code>IMjmlTemplateService</code> from the EmailTemplating module instead of inline <code>StubbleBuilder</code> + <code>MjmlRenderer</code>. Removed redundant <code>Mjml.Net</code>, <code>Stubble.Core</code>, <code>Stubble.Extensions.JsonNet</code> package references from WorkflowAdditions</li>
</ul>
<h2>Architecture</h2>
<p>Email operations are now cleanly split across reusable packages and per-project responsibility:</p>

Concern | Package/Project
-- | --
Send abstraction (IEmailSender) | PropertyBrokersDigital.Email
Graph send + read implementation | PropertyBrokersDigital.Email.Graph
MJML template rendering | PropertyBrokers.OrchardCore.EmailTemplating
Queueing, retry, scheduling | Each consuming project


<h3>Why queues stay per-project</h3>
<p>JobManager uses a database-backed queue with exponential backoff retry (5, 10, 20 min). SurveyJS uses an in-memory fire-and-forget queue. The requirements are too different to abstract — a shared queue would either be over-engineered or force one pattern on both.</p>
<h3>How retry works across the boundary</h3>
<p><code>IEmailSender.SendAsync()</code> returns an <code>EmailSendResult</code> with <code>Succeeded</code>, <code>Errors</code>, and optional <code>GraphMetadata</code>. The consuming project decides what to do with it:</p>
<ul>
<li><strong>JobManager</strong> — if <code>Succeeded</code> is <code>false</code>, throws, which triggers <code>HandleEmailError()</code> to record the failure in DB. On the next background task run, <code>ShouldProcessEmail()</code> checks the backoff window before retrying. After max attempts, the email is marked permanently failed.</li>
<li><strong>SurveyJS</strong> — if <code>Succeeded</code> is <code>false</code>, logs the error and moves on. The user can re-trigger the action.</li>
</ul>
<p>The package reports outcomes, the consumer owns the policy.</p>

</body>
</html>