### PR TITLE
Sync ENV workflow task.

### DIFF
--- a/Views/Items/EnvironmentVariableTask.Fields.Edit.cshtml
+++ b/Views/Items/EnvironmentVariableTask.Fields.Edit.cshtml
@@ -3,7 +3,7 @@
 
 <div class="form-group" asp-validation-class-for="VariableName">
     <label for="VariableName">@T["Environment Variable Name"]</label>
-    <input type="text" asp-for="VariableName" class="form-control code" id="VariableName" name="VariableName" />
+    <input type="text" asp-for="VariableName" class="form-control code" />
     <span asp-validation-for="VariableName"></span>
     <span class="hint">@T["The name of the environment variable to check. Default is 'Sync'. Supports Liquid expressions."]</span>
     <span class="hint">@T["The task will check if the variable value is 'true', '1', 'yes' (returns True), 'false', '0', 'no' (returns False), or doesn't exist (returns NotFound)."]</span>


### PR DESCRIPTION
 ## Summary
  - The `EnvironmentVariableTask` activity in the workflow designer was stuck on `Sync` — any other value you typed reverted on save.
  - Root cause: the edit view hard-coded `id="VariableName" name="VariableName"` on the input alongside `asp-for="VariableName"`. OrchardCore's `ActivityDisplayDriver` binds the POSTed form via
  `TryUpdateModelAsync(viewModel, Prefix)` using a shape-based prefix, and `asp-for` normally renders that prefix into the input name. The manual `name` override stripped the prefix, so the model binder never
  populated `model.VariableName`, and the view model's default (`"Sync"`) won with every save.
  - Fix removes the redundant `id`/`name` attributes so `asp-for` handles naming — matching the pattern used by every other activity in this module (`ValidateJsonTask`, `GoogleAnalyticsEventTask`, etc.).
